### PR TITLE
Sticky table of contents

### DIFF
--- a/configs/mirrors.json
+++ b/configs/mirrors.json
@@ -101,7 +101,7 @@
       "alternative": "http://mirrors.ocf.berkeley.edu/blender/"
     },
     "centos": {
-      "name": "CentOS (<8)",
+      "name": "CentOS (≤8)",
       "page": "Distributions",
       "rsync": {
         "host": "msync.centos.org",

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -164,6 +164,8 @@ body>h1 {
   }
 
   .projects-container>.toc {
+    display: flex;
+    flex-direction: column;
     text-decoration: none;
     text-align: left;
     position: sticky;
@@ -172,6 +174,13 @@ body>h1 {
     float: left;
     height: fit-content;
     width: 70%;
+    overflow-y: scroll;
+    scrollbar-width: 0px;
+    -ms-overflow-style: none;
+  }
+
+  .projects-container>.toc::-webkit-scrollbar {
+    display:none;
   }
 
   .toc>.toc-section-content>ul>li>a {
@@ -182,7 +191,6 @@ body>h1 {
     border: none;
     border-radius: 5px;
     margin: 5px;
-    margin-right: calc(100% - 200px);
     margin-left: 0px;
     width: fit-content;
     background-color: white;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -149,13 +149,20 @@ body > h1 {
 /* For projects.gohtml */
 @media screen and (min-width: 800px) {
   .projects-container {
-    display: flex;
+    display: grid;
+    grid-area: span;
+    grid-template-columns: 20vw 80vw;
     flex-direction: row;
     justify-content: space-between;
   }
 
   .projects-container > .toc {
-    width: 20%;
+    position: sticky;
+    top: 10px;
+    bottom: 10px;
+    float: left;
+    height: 30%;
+    width: 70%; 
   }
 
   .projects-container > .list {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -171,10 +171,10 @@ body>h1 {
     position: sticky;
     top: 10px;
     bottom: 10px;
-    float: left;
-    height: fit-content;
-    width: 70%;
     overflow-y: scroll;
+    height: 100vh;
+    float: left;
+    width: 70%;
     scrollbar-width: 0px;
     -ms-overflow-style: none;
   }
@@ -213,9 +213,7 @@ body>h1 {
   }
 
   .toc-section-content {
-    display: block;
-    max-height: fit-content;
-    overflow: hidden;
+    min-height: fit-content !important;
     transition: max-height 0.2s ease-out;
   }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -22,6 +22,7 @@ header {
   padding-bottom: 0;
   border-bottom: yellow solid 3px;
 }
+
 header ul {
   list-style-type: none;
   margin: 0;
@@ -29,12 +30,14 @@ header ul {
   overflow: hidden;
   background-color: rgb(40, 104, 40);
 }
+
 /* mobile */
 @media screen and (max-width: 800px) {
   header li {
     float: none;
   }
 }
+
 /* desktop */
 @media screen and (min-width: 800px) {
   header li {
@@ -42,7 +45,7 @@ header ul {
   }
 }
 
-header li > a {
+header li>a {
   font-size: 20px;
   display: block;
   color: white;
@@ -50,6 +53,7 @@ header li > a {
   padding: 14px 16px;
   text-decoration: none;
 }
+
 header li a:hover {
   background-color: darkgreen;
 }
@@ -62,9 +66,11 @@ footer {
   display: block;
   text-align: center;
 }
+
 footer a {
   color: white;
 }
+
 footer b * {
   white-space: nowrap;
 }
@@ -77,7 +83,8 @@ footer b * {
   flex-direction: column;
   margin: 0;
 }
-body > h1 {
+
+body>h1 {
   font-size: 50px;
   padding: 100px;
   margin-top: 0;
@@ -105,7 +112,7 @@ body > h1 {
     align-items: center;
   }
 
-  .vertlist > b {
+  .vertlist>b {
     text-align: center;
     font-size: 30px;
   }
@@ -127,18 +134,18 @@ body > h1 {
     align-items: left;
   }
 
-  .vertlist > img {
+  .vertlist>img {
     margin-left: 30px;
   }
 
-  .vertlist > b {
+  .vertlist>b {
     padding-left: 30px;
     padding-right: 30px;
     text-align: left;
     font-size: 30px;
   }
 
-  .vertlist > p {
+  .vertlist>p {
     text-align: left;
     padding-left: 30px;
     padding-right: 30px;
@@ -156,22 +163,61 @@ body > h1 {
     justify-content: space-between;
   }
 
-  .projects-container > .toc {
+  .projects-container>.toc {
+    text-decoration: none;
+    text-align: left;
     position: sticky;
     top: 10px;
     bottom: 10px;
     float: left;
-    height: 30%;
-    width: 70%; 
+    height: fit-content;
+    width: 70%;
   }
 
-  .projects-container > .list {
+  .toc>.toc-section-content>ul>li>a {
+    text-decoration:none;
+  }
+
+  .toc-heading {
+    border: none;
+    border-radius: 5px;
+    margin: 5px;
+    margin-right: calc(100% - 200px);
+    margin-left: 0px;
+    width: fit-content;
+    background-color: white;
+    font-size: 16px;
+    padding: 4px;
+  }
+
+  .toc-heading:hover {
+    background-color: #ccc;
+  }
+
+  .active:before {
+    content: "\002B" !important;
+    color: black;
+  }
+
+  .toc-heading:before {
+    content: '\2212';
+    color: black;
+  }
+
+  .toc-section-content {
+    display: block;
+    max-height: fit-content;
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
+  }
+
+  .projects-container>.list {
     width: 75%;
   }
 
   .projects {
     padding-left: 5%;
-  }  
+  }
 }
 
 @media screen and (max-width: 800px) {
@@ -183,12 +229,12 @@ body > h1 {
     display: flex;
   }
 
-  .projects-container > .toc {
+  .projects-container>.toc {
     /* remove from flexbox and hide */
     display: none;
   }
 
-  .projects-container > .list {
+  .projects-container>.list {
     width: 100%;
   }
 }
@@ -209,7 +255,7 @@ body > h1 {
   overflow: hidden;
 }
 
-.distro > a {
+.distro>a {
   color: rgb(40, 104, 40);
 }
 
@@ -233,6 +279,7 @@ body > h1 {
     margin: 0;
   }
 }
+
 /* desktop */
 @media screen and (min-width: 800px) {
   main {
@@ -247,10 +294,12 @@ p {
   color: black;
   line-height: 24px;
 }
+
 a {
   padding: 0;
   color: green;
 }
+
 /* For history.gohtml */
 .history {
   display: flex;

--- a/static/js/projects.js
+++ b/static/js/projects.js
@@ -1,11 +1,15 @@
 // TODO: Make a working collapsable
 
-var collapsable = document.getElementById("collapsable"); // TODO: set id of "linux distributions", "software", and "miscellaneous" to collapsable in toc after making the following for loop work
+var collapsable = document.getElementsByClassName("toc-heading"); // TODO: set id of "linux distributions", "software", and "miscellaneous" to collapsable in toc after making the following for loop work
 
 for (let i = 0; i < collapsable.length; i++) {
-    collapsable[i].addEventListener("click", function() {
-        this.classList.toggle("active");
-
-    })
-    
+  collapsable[i].addEventListener("click", function () {
+    this.classList.toggle("active");
+    var content = this.nextElementSibling;
+    if (content.style.display === "block") {
+      content.style.display = "none";
+    } else {
+      content.style.display = "block";
+    }
+  })
 }

--- a/static/js/projects.js
+++ b/static/js/projects.js
@@ -1,5 +1,3 @@
-// TODO: Make a working collapsable
-
 var collapsable = document.getElementsByClassName("toc-heading"); // TODO: set id of "linux distributions", "software", and "miscellaneous" to collapsable in toc after making the following for loop work
 
 for (let i = 0; i < collapsable.length; i++) {

--- a/static/js/projects.js
+++ b/static/js/projects.js
@@ -1,0 +1,11 @@
+// TODO: Make a working collapsable
+
+var collapsable = document.getElementById("collapsable"); // TODO: set id of "linux distributions", "software", and "miscellaneous" to collapsable in toc after making the following for loop work
+
+for (let i = 0; i < collapsable.length; i++) {
+    collapsable[i].addEventListener("click", function() {
+        this.classList.toggle("active");
+
+    })
+    
+}

--- a/templates/history.gohtml
+++ b/templates/history.gohtml
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <title>Mirror - History</title>
     {{template "head.gohtml" .}}
 </head>
 

--- a/templates/home.gohtml
+++ b/templates/home.gohtml
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <title>Mirror - Home</title>
     {{template "head.gohtml" .}}
 </head>
 

--- a/templates/map.gohtml
+++ b/templates/map.gohtml
@@ -5,7 +5,7 @@
 <head>
     {{template "head.gohtml" .}}
     <link rel="stylesheet" href="/css/map.css" />
-    <title>Mirror Map</title>
+    <title>Mirror - Map</title>
     <script>
       const distros = [
         {{ range . }}

--- a/templates/projects.gohtml
+++ b/templates/projects.gohtml
@@ -35,6 +35,7 @@
 
 <head>
     <title>Mirror - Projects</title>
+    <script defer src="js/projects.js"></script>
     {{template "head.gohtml" .}}
 </head>
 
@@ -46,37 +47,42 @@
             <div class="toc">
                 <h3 class="center">Table of Contents</h3>
                 <hr style="padding: 0px">
-                <b> Distributions </b>
-                <ul>
-                    {{ range .Distributions }}
-                    {{if .Official}}
-                    <li><a class="bold" href="#{{ .Short }}">{{ .Name }}</a></li>
-                    {{ else }}
-                    <li><a href="#{{ .Short }}">{{ .Name }}</a></li>
-                    {{ end }}
-                    {{ end }}
-                </ul>
-                <b> Software </b>
-                <ul>
-                    {{ range .Software }}
-                    {{if .Official}}
-                    <li><a class="bold" href="#{{ .Short }}">{{ .Name }}</a></li>
-                    {{ else }}
-                    <li><a href="#{{ .Short }}">{{ .Name }}</a></li>
-                    {{ end }}
-                    {{ end }}
-                </ul>
-                <b> Miscellaneous </b>
-                <ul>
-                    {{ range .Miscellaneous }}
-                    {{ if .Official }}
-                    <li><a class="bold" href="#{{ .Short }}">{{ .Name }}</a></li>
-                    {{ else }}
-                    <li><a href="#{{ .Short }}">{{ .Name }}</a></li>
-                    {{ end }}
-                    {{ end }}
-                </ul>
-                </ul>
+                <button type="button" class="toc-heading"> <b> Distributions </b> </button>
+                <div class="toc-section-content" style="display: block">
+                    <ul>
+                        {{ range .Distributions }}
+                        {{if .Official}}
+                        <li><a class="bold" href="#{{ .Short }}">{{ .Name }}</a></li>
+                        {{ else }}
+                        <li><a href="#{{ .Short }}">{{ .Name }}</a></li>
+                        {{ end }}
+                        {{ end }}
+                    </ul>
+                </div>
+                <button type="button" class="toc-heading"> <b> Software </b> </button>
+                <div class="toc-section-content" style="display: block">
+                    <ul>
+                        {{ range .Software }}
+                        {{if .Official}}
+                        <li><a class="bold" href="#{{ .Short }}">{{ .Name }}</a></li>
+                        {{ else }}
+                        <li><a href="#{{ .Short }}">{{ .Name }}</a></li>
+                        {{ end }}
+                        {{ end }}
+                    </ul>
+                </div>
+                <button type="button" class="toc-heading"> <b> Miscellaneous </b> </button>
+                <div class="toc-section-content" style="display: block">
+                    <ul>
+                        {{ range .Miscellaneous }}
+                        {{ if .Official }}
+                        <li><a class="bold" href="#{{ .Short }}">{{ .Name }}</a></li>
+                        {{ else }}
+                        <li><a href="#{{ .Short }}">{{ .Name }}</a></li>
+                        {{ end }}
+                        {{ end }}
+                    </ul>
+                </div>
             </div>
             <div class="list">
                 <h1 id="distributions" class="center">Linux Distributions</h1>

--- a/templates/projects.gohtml
+++ b/templates/projects.gohtml
@@ -34,6 +34,7 @@
 {{end}}
 
 <head>
+    <title>Mirror - Projects</title>
     {{template "head.gohtml" .}}
 </head>
 

--- a/templates/projects.gohtml
+++ b/templates/projects.gohtml
@@ -46,9 +46,9 @@
         <div class="projects-container">
             <div class="toc">
                 <h3 class="center">Table of Contents</h3>
-                <hr style="padding: 0px">
+                <hr style="padding: 0px; width: 90%">
                 <button type="button" class="toc-heading"> <b> Distributions </b> </button>
-                <div class="toc-section-content" style="display: block">
+                <div class="toc-section-content" style="display: none">
                     <ul>
                         {{ range .Distributions }}
                         {{if .Official}}
@@ -60,7 +60,7 @@
                     </ul>
                 </div>
                 <button type="button" class="toc-heading"> <b> Software </b> </button>
-                <div class="toc-section-content" style="display: block">
+                <div class="toc-section-content" style="display: none">
                     <ul>
                         {{ range .Software }}
                         {{if .Official}}
@@ -71,8 +71,9 @@
                         {{ end }}
                     </ul>
                 </div>
+                {{if .Miscellaneous}} 
                 <button type="button" class="toc-heading"> <b> Miscellaneous </b> </button>
-                <div class="toc-section-content" style="display: block">
+                <div class="toc-section-content" style="display: none">
                     <ul>
                         {{ range .Miscellaneous }}
                         {{ if .Official }}
@@ -83,6 +84,8 @@
                         {{ end }}
                     </ul>
                 </div>
+                {{else}}
+                {{end}}
             </div>
             <div class="list">
                 <h1 id="distributions" class="center">Linux Distributions</h1>
@@ -95,11 +98,14 @@
                 {{ range .Software }}
                 {{ template "project" . }}
                 {{ end }}
+                {{if .Miscellaneous}}
                 <h1 id="miscellaneous" class="center">Miscellaneous</h1>
                 <hr>
                 {{ range .Miscellaneous }}
                 {{ template "project" . }}
                 {{ end }}
+                {{else}}
+                {{end}}
             </div>
         </div>
     </main>


### PR DESCRIPTION
Made table of contents scroll with page and made sections of the TOC collapsable to make it easier to use on screens that may not be able to fit the full table.

I also gave all of the individual pages page titles. (before they just showed as https://mirror.clarkson.edu/x)