### PR TITLE
Big Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ MAXMIND_LICENSE_KEY=
 INFLUX_TOKEN=
 ```
 
+## NGINX
+
+The NGINX aggregator requires this `access_log` configuration:
+
+```nginx
+log_format config '"$time_local" "$remote_addr" "$request" "$status" "$body_bytes_sent" "$request_length" "$http_user_agent"';
+access_log /var/log/nginx/access.log config;
+```
+
 ## Dependencies
 
 Quick-Fedora-Mirror requires `zsh`

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -1,4 +1,4 @@
-package main
+package aggregator
 
 import (
 	"time"
@@ -18,9 +18,14 @@ type Aggregator[T any] interface {
 	Send(writer api.WriteAPI)
 }
 
-// StartAggregator starts the aggregator with the given Aggregator implementation, channel of type T, influxdb QueryAPI and WriteAPI.
-// It returns the lastUpdated time and an error if any occurred during initialization.
-func StartAggregator[T any](aggregator Aggregator[T], c <-chan T) (lastUpdated time.Time, err error) {
+// StartAggregator is a function that starts an aggregator process to continuously
+// read data from a channel, aggregate it using the provided aggregator, and
+// send the aggregated data to a writer at regular intervals.
+//
+// # It takes an influxdb reader, writer, an aggregator over type T, and a channel of type T
+//
+// It returns the time of the last update (from influxdb), which can be used as a filter
+func StartAggregator[T any](reader api.QueryAPI, writer api.WriteAPI, aggregator Aggregator[T], c <-chan T) (lastUpdated time.Time, err error) {
 	lastUpdated, err = aggregator.Init(reader)
 	if err != nil {
 		return lastUpdated, err

--- a/aggregator/aggregator_rsyncd.go
+++ b/aggregator/aggregator_rsyncd.go
@@ -1,9 +1,8 @@
-package main
+package aggregator
 
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -45,7 +44,6 @@ func (a *RSYNCDAggregator) Init(reader api.QueryAPI) (lastUpdated time.Time, err
 		result, err = reader.Query(context.Background(), request)
 
 		if err != nil {
-			logging.Warn("Failed to querying influxdb rsyncd statistics", err)
 			time.Sleep(time.Second)
 			continue
 		}
@@ -54,7 +52,7 @@ func (a *RSYNCDAggregator) Init(reader api.QueryAPI) (lastUpdated time.Time, err
 	}
 
 	if result == nil {
-		return time.Time{}, errors.New("Error querying influxdb for rsyncd stat")
+		return time.Time{}, err
 	}
 
 	for result.Next() {

--- a/aggregators.go
+++ b/aggregators.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"net"
+	"time"
+
+	"github.com/COSI-Lab/Mirror/aggregator"
+	"github.com/COSI-Lab/Mirror/config"
+	"github.com/COSI-Lab/Mirror/logging"
+	"github.com/influxdata/influxdb-client-go/v2/api"
+)
+
+func StartNGINXAggregator(reader api.QueryAPI, writer api.WriteAPI, config *config.File) (chan<- aggregator.NGINXLogEntry, time.Time, error) {
+	nginxAg := aggregator.NewNGINXProjectAggregator()
+	nginxAg.AddMeasurement("nginx", func(re aggregator.NGINXLogEntry) bool {
+		return true
+	})
+
+	// Add subnet aggregators
+	for name, subnetStrings := range config.Subnets {
+		subnets := make([]*net.IPNet, 0)
+		for _, subnetString := range subnetStrings {
+			_, subnet, err := net.ParseCIDR(subnetString)
+			if err != nil {
+				logging.Warnf("Failed to parse subnet %q for %q", subnetString, name)
+				continue
+			}
+			subnets = append(subnets, subnet)
+		}
+
+		if len(subnets) == 0 {
+			logging.Warn("No valid subnets for", name)
+			continue
+		}
+
+		nginxAg.AddMeasurement(name, func(re aggregator.NGINXLogEntry) bool {
+			for _, subnet := range subnets {
+				if subnet.Contains(re.IP) {
+					return true
+				}
+			}
+			return false
+		})
+
+		logging.Infof("Added subnet aggregator for %q", name)
+	}
+
+	nginxMetrics := make(chan aggregator.NGINXLogEntry)
+	nginxLastUpdated, err := aggregator.StartAggregator[aggregator.NGINXLogEntry](reader, writer, nginxAg, nginxMetrics)
+
+	return nginxMetrics, nginxLastUpdated, err
+}
+
+func StartRSYNCAggregator(reader api.QueryAPI, writer api.WriteAPI) (chan<- aggregator.RSCYNDLogEntry, time.Time, error) {
+	rsyncAg := aggregator.NewRSYNCProjectAggregator()
+
+	rsyncMetrics := make(chan aggregator.RSCYNDLogEntry)
+	rsyncLastUpdated, err := aggregator.StartAggregator[aggregator.RSCYNDLogEntry](reader, writer, rsyncAg, rsyncMetrics)
+
+	return rsyncMetrics, rsyncLastUpdated, err
+}

--- a/config/configFile.go
+++ b/config/configFile.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"text/template"
 
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -99,46 +98,6 @@ func (config *File) GetProjects() []Project {
 	})
 
 	return projects
-}
-
-// CreateRSCYNDConfig writes a rsyncd.conf file to the given writer based on the config
-//
-// Consider passing a bufio.Write to this function
-func (config *File) CreateRSCYNDConfig(w io.Writer) error {
-	tmpl := `# This is a generated file. Do not edit manually.
-	uid = nobody
-	gid = nogroup
-	use chroot = yes
-	max connections = 0
-	pid file = /var/run/rsyncd.pid
-	motd file = /etc/rsyncd.motd
-	log file = /var/log/rsyncd.log
-	log format = %t %o %a %m %f %b
-	dont compress = *.gz *.tgz *.zip *.z *.Z *.rpm *.deb *.bz2 *.tbz2 *.xz *.txz *.rar
-	refuse options = checksum delete
-	{{ range . }}
-	[{{ .Short }}]
-		comment = {{ .Name }}
-		path = /storage/{{ .Short }}
-		exclude = lost+found/
-		read only = true
-		ignore nonreadable = yes{{ end }}
-	`
-
-	var filteredProjects []*Project
-	for _, project := range config.Projects {
-		if project.PublicRsync {
-			filteredProjects = append(filteredProjects, project)
-		}
-	}
-
-	t := template.Must(template.New("rsyncd.conf").Parse(tmpl))
-	err := t.Execute(w, filteredProjects)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Validate checks the config file for a few properties

--- a/config/rsyncd.go
+++ b/config/rsyncd.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"io"
+	"text/template"
+)
+
+// CreateRSCYNDConfig writes a rsyncd.conf file to the given writer based on the Config struct
+func (config *File) CreateRSCYNDConfig(w io.Writer) error {
+	tmpl := `# This is a generated file. Do not edit manually.
+	uid = nobody
+	gid = nogroup
+	use chroot = yes
+	max connections = 0
+	pid file = /var/run/rsyncd.pid
+	motd file = /etc/rsyncd.motd
+	log file = /var/log/rsyncd.log
+	log format = %t %o %a %m %f %b
+	dont compress = *.gz *.tgz *.zip *.z *.Z *.rpm *.deb *.bz2 *.tbz2 *.xz *.txz *.rar
+	refuse options = checksum delete
+	{{ range . }}
+	[{{ .Short }}]
+		comment = {{ .Name }}
+		path = /storage/{{ .Short }}
+		exclude = lost+found/
+		read only = true
+		ignore nonreadable = yes{{ end }}
+	`
+
+	var filteredProjects []*Project
+	for _, project := range config.Projects {
+		if project.PublicRsync {
+			filteredProjects = append(filteredProjects, project)
+		}
+	}
+
+	t := template.Must(template.New("rsyncd.conf").Parse(tmpl))
+	err := t.Execute(w, filteredProjects)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/config/tokens_test.go
+++ b/config/tokens_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/COSI-Lab/Mirror/config"
 )
 
-// Test tokens.txt parsing
+// Test tokens.toml parsing
 func TestTokens(t *testing.T) {
 	example := `
 		[[tokens]]

--- a/influx.go
+++ b/influx.go
@@ -7,17 +7,12 @@ import (
 	"github.com/influxdata/influxdb-client-go/v2/api"
 )
 
-var writer api.WriteAPI
-var reader api.QueryAPI
-
 // SetupInfluxClients connects to influxdb and sets up the db clients
-func SetupInfluxClients(token string) {
+func SetupInfluxClients(token string) (reader api.QueryAPI, writer api.WriteAPI) {
 	// create new client with default option for server url authenticate by token
 	options := influxdb2.DefaultOptions()
 	options.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
 
 	client := influxdb2.NewClientWithOptions("https://mirror.clarkson.edu:8086", token, options)
-
-	writer = client.WriteAPI("COSI", "stats")
-	reader = client.QueryAPI("COSI")
+	return client.QueryAPI("COSI"), client.WriteAPI("COSI", "stats")
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -21,8 +21,6 @@ const (
 	WarnT
 	// ErrorT is used for logging error [ERROR] messages
 	ErrorT
-	// PanicT is used for logging panic [PANIC] messages
-	PanicT
 	// SuccessT is used for logging success [SUCCESS] messages
 	SuccessT
 )
@@ -37,8 +35,6 @@ func (mt messageType) String() string {
 		return "\033[1m\033[33m[WARN]    \033[0m| "
 	case ErrorT:
 		return "\033[1m\033[31m[ERROR]   \033[0m| "
-	case PanicT:
-		return "\033[1m\033[34m[PANIC]   \033[0m| "
 	case SuccessT:
 		return "\033[1m\033[32m[SUCCESS] \033[0m| "
 	default:
@@ -77,11 +73,6 @@ func ErrorLogEntry(message string) LogEntry {
 	return NewLogEntry(ErrorT, message)
 }
 
-// PanicLogEntry creates a new LogEntry with the current time and [PANIC] tag
-func PanicLogEntry(message string) LogEntry {
-	return NewLogEntry(PanicT, message)
-}
-
 // SuccessLogEntry creates a new LogEntry with the current time and [SUCCESS] tag
 func SuccessLogEntry(message string) LogEntry {
 	return NewLogEntry(SuccessT, message)
@@ -102,7 +93,19 @@ func (le LogEntry) Log() {
 	logger.Unlock()
 }
 
-func logf(mt messageType, format string, v ...interface{}) {
+// Joins a `v ...any` slice into a string with spaces between each element
+func join(v ...any) string {
+	s := ""
+	for i := 0; i < len(v); i++ {
+		s += fmt.Sprint(v[i])
+		if i != len(v)-1 {
+			s += " "
+		}
+	}
+	return s
+}
+
+func logf(mt messageType, format string, v ...any) {
 	logger.Lock()
 	if format[len(format)-1] != '\n' {
 		fmt.Printf("%s %s %s\n", time.Now().Format(tm), mt.String(), fmt.Sprintf(format, v...))
@@ -112,70 +115,58 @@ func logf(mt messageType, format string, v ...interface{}) {
 	logger.Unlock()
 }
 
-func logln(mt messageType, v ...interface{}) {
+func logln(mt messageType, v ...any) {
 	logger.Lock()
-	fmt.Printf("%s %s %s\n", time.Now().Format(tm), mt.String(), fmt.Sprint(v...))
+	fmt.Printf("%s %s %s\n", time.Now().Format(tm), mt.String(), join(v...))
 	logger.Unlock()
 }
 
 // Infof formats a message and logs it with [INFO] tag, it adds a newline if the message didn't end with one
-func Infof(format string, v ...interface{}) {
+func Infof(format string, v ...any) {
 	logf(InfoT, format, v...)
 }
 
 // Info logs a message with [INFO] tag and a newline
-func Info(v ...interface{}) {
+func Info(v ...any) {
 	logln(InfoT, v...)
 }
 
-// WarnF formats a message and logs it with [WARN] tag, it adds a newline if the message didn't end with one
-func WarnF(format string, v ...interface{}) {
+// Warnf formats a message and logs it with [WARN] tag, it adds a newline if the message didn't end with one
+func Warnf(format string, v ...any) {
 	logf(WarnT, format, v...)
 }
 
 // Warn logs a message with [WARN] tag and a newline
-func Warn(v ...interface{}) {
+func Warn(v ...any) {
 	logln(WarnT, v...)
 }
 
 // Errorf formats a message and logs it with [ERROR] tag, it adds a newline if the message didn't end with one
-func Errorf(format string, v ...interface{}) {
+func Errorf(format string, v ...any) {
 	logf(ErrorT, format, v...)
 }
 
 // Error logs a message with [ERROR] tag and a newline
-func Error(v ...interface{}) {
+func Error(v ...any) {
 	logln(ErrorT, v...)
 }
 
-// Panicf formats a message and logs it with [PANIC] tag, it adds a newline if the message didn't end with one
-// Note: this function does not call panic() or otherwise stops the program
-func Panicf(format string, v ...interface{}) {
-	logf(PanicT, format, v...)
-}
-
-// Panic logs a message with [PANIC] tag and a newline
-// Note: this function does not call panic() or otherwise stops the program
-func Panic(v ...interface{}) {
-	logln(PanicT, v...)
-}
-
 // Successf formats a message and logs it with [SUCCESS] tag, it adds a newline if the message didn't end with one
-func Successf(format string, v ...interface{}) {
+func Successf(format string, v ...any) {
 	logf(SuccessT, format, v...)
 }
 
 // Success logs a message with [SUCCESS] tag and a newline
-func Success(v ...interface{}) {
+func Success(v ...any) {
 	logln(SuccessT, v...)
 }
 
 // Logf formats a message and logs it with provided tag, it adds a newline if the message didn't end with one
-func Logf(mt messageType, format string, v ...interface{}) {
+func Logf(mt messageType, format string, v ...any) {
 	logf(mt, format, v...)
 }
 
 // Log logs a message with provided tag and a newline
-func Log(mt messageType, v ...interface{}) {
+func Log(mt messageType, v ...any) {
 	logln(mt, v...)
 }


### PR DESCRIPTION
This PR replaces #48  

- merges random subprojects into this repo
- move config file handling into it's own module
- remove most placeholders
- interface based aggregators (more stable and easier to add more)
- interface based and context aware scheduling (needs a bit more work)
- updates dependencies
- adds more CI
- remove broken webserver caching
- go 1.21

Second pass:

- logging: remove `Panic`
- moved aggregator logic to it's own module
- scheduler: now returns an error if _any_ task setup fails
- scheduler: will create `/var/log/mirror` if it doesn't exist
- live map: websocket messages are now grouped by time instead of by a fixed number
- config: moved "rsyncd.conf" generation into its own file
- influxdb api connection is no longer a global variable
- map.js: improved the code clarity and performance a little bit