### PR TITLE
Big Refactor

### DIFF
--- a/configs/mirrors.json
+++ b/configs/mirrors.json
@@ -248,7 +248,9 @@
       "page": "Distributions",
       "script": {
         "command": "./scripts/archvsync/bin/ftpsync",
-        "arguments": ["sync:all"],
+        "arguments": [
+          "sync:all"
+        ],
         "syncs_per_day": 4
       },
       "official": true,
@@ -351,7 +353,10 @@
       "script": {
         "syncs_per_day": 4,
         "command": "./scripts/quick-fedora-mirror/quick-fedora-mirror",
-        "arguments": ["-c", "configs/quick-fedora-mirror.conf"]
+        "arguments": [
+          "-c",
+          "configs/quick-fedora-mirror.conf"
+        ]
       },
       "official": true,
       "homepage": "https://www.fedoraproject.org/",
@@ -435,7 +440,9 @@
       "script": {
         "syncs_per_day": 4,
         "command": "/bin/python3",
-        "arguments": ["scripts/kicad/kicad_sync.py"]
+        "arguments": [
+          "scripts/kicad/kicad_sync.py"
+        ]
       },
       "official": true,
       "homepage": "https://www.kicad.org",
@@ -582,6 +589,22 @@
       "alternative": "http://mirrors.mit.edu/parrot/",
       "icon": "img/projects/parrot.svg",
       "torrents": "/storage/parrot/iso/*/"
+    },
+    "photonvision": {
+      "name": "PhotonVision archives",
+      "page": "Software",
+      "rsync": {
+        "host": "maven.photonvision.org",
+        "src": "reposilite-data",
+        "dest": "/storage/photonvision",
+        "syncs_per_day": 1,
+        "options": "-avzrHy --no-perms --no-group --no-owner --ignore-errors --exclude \".~tmp~\""
+      },
+      "official": true,
+      "homepage": "https://photonvision.org/",
+      "color": "#006492",
+      "publicRsync": true,
+      "icon": "img/projects/photonvision.png"
     },
     "raspbian": {
       "name": "Raspbian",

--- a/static/img/projects/photonvision.png
+++ b/static/img/projects/photonvision.png
@@ -1,0 +1,12 @@
+--2024-07-31 21:47:50--  https://photonvision.org/images/PhotonVision-Icon-BG.png
+Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
+Resolving photonvision.org (photonvision.org)... 148.135.85.134
+Connecting to photonvision.org (photonvision.org)|148.135.85.134|:443... connected.
+HTTP request sent, awaiting response... 200 OK
+Length: 32295 (32K) [image/png]
+Saving to: ‘PhotonVision-Icon-BG.png’
+
+     0K .......... .......... .......... .                    100%  347K=0.09s
+
+2024-07-31 21:47:51 (347 KB/s) - ‘PhotonVision-Icon-BG.png’ saved [32295/32295]
+


### PR DESCRIPTION
This PR replaces #48 and #57 

- merges random subprojects into this repo
- move config file handling into it's own module
- remove most placeholders
- interface based aggregators (more stable and easier to add more)
- interface based and context aware scheduling (needs a bit more work)
- updates dependencies
- adds more CI
- remove broken webserver caching
- go 1.21

Second pass:

- logging: remove Panic
- moved aggregator logic to it's own module
- scheduler: now returns an error if any task setup fails
- scheduler: will create /var/log/mirror if it doesn't exist
- live map: websocket messages are now grouped by time instead of by a fixed number
- config: moved "rsyncd.conf" generation into its own file
- influxdb api connection is no longer a global variable
- map.js: improved the code clarity and performance a little bit

