### PR TITLE
Mirror is now on kicad.org, update mirrors.json to reflect this

### DIFF
--- a/configs/mirrors.json
+++ b/configs/mirrors.json
@@ -437,7 +437,7 @@
         "command": "/bin/python3",
         "arguments": ["scripts/kicad/kicad_sync.py"]
       },
-      "official": false,
+      "official": true,
       "homepage": "https://www.kicad.org",
       "color": "#ff7700",
       "publicRsync": true,


### PR DESCRIPTION
Starting to see some traffic for Kicad on the map!