### PR TITLE
Point rsync to new tails domain

### DIFF
--- a/configs/mirrors.json
+++ b/configs/mirrors.json
@@ -711,7 +711,7 @@
       "page": "Distributions",
       "rsync": {
         "options": "-avzrHy --no-perms --no-group --no-owner --delete --delete-delay --delay-updates --ignore-errors --exclude \".~tmp~\"",
-        "host": "mirrors.rsync.tails.boum.org",
+        "host": "rsync.tails.net",
         "src": "amnesia-archive",
         "dest": "/storage/tailsos",
         "syncs_per_day": 24


### PR DESCRIPTION
Tails is migrating from the tails.boum.org to tails.net.
Updated mirrors.json to point to the new domain.